### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -23,7 +23,7 @@ jobs:
 
             -   uses: actions/checkout@master
             -   name: Publish to Registry
-                uses: elgohr/Publish-Docker-Github-Action@master
+                uses: elgohr/Publish-Docker-Github-Action@v5
                 with:
                     name: waseju/root_tissue_segmentation
                     username: waseju


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore